### PR TITLE
Added missing #include, cleared user input

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 #include <fstream>
+#include <array>
 using namespace std;
 double alpha(int n){
     if(n == 0)
@@ -222,6 +223,8 @@ int main() {
     cin >> qt;
     while (qt <= 0 or qt > 254){
         cout << "Invalid input, enter custom quantization from 1-254: " << endl;
+        cin.clear();
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
         cin >> qt;
     }
     for(int x=0;x<runs;++x) {


### PR DESCRIPTION
The code was missing the #include <array>. The fix to the infinite loop was to use cin.clear() and cin.ignore to able to input another value or character. Now it loops only when necessary.